### PR TITLE
Add Docker Compose for PostgreSQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  postgres:
+    image: postgres
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_USER=test
+      - POSTGRES_PASSWORD=test
+      - POSTGRES_DB=whatsapp
+    volumes:
+      - postgres:/var/lib/postgresql/data
+volumes:
+  postgres:


### PR DESCRIPTION
The new version of WhatsApp Clone is a great work.
I think that it is preparing, but I confirmed the operation with docker-compose for issues  #28.

```bash
$ git clone https://github.com/Urigo/WhatsApp-Clone-server.git whatsapp-server-express
$ cd whatsapp-server-express
$ docker-compose up -d
$ yarn install
$ yarn start --add-sample-data
```
